### PR TITLE
(Chore) Allow setting Load Balancer grace period

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_ecs_service" "main" {
 
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
-  health_check_grace_period_seconds = var.lb_target_group_arn == "" ? null : 30
+  health_check_grace_period_seconds = var.lb_target_group_arn == "" ? null : "${var.lb_health_check_grace_period_seconds}"
 
   dynamic "load_balancer" {
     for_each = var.lb_target_group_arn == "" ? [] : [1]
@@ -76,7 +76,7 @@ resource "aws_ecs_service" "main_awsvpc" {
 
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
-  health_check_grace_period_seconds = var.lb_target_group_arn == "" ? null : 30
+  health_check_grace_period_seconds = var.lb_target_group_arn == "" ? null : "${var.lb_health_check_grace_period_seconds}"
 
   dynamic "load_balancer" {
     for_each = var.lb_target_group_arn == "" ? [] : [1]

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,9 @@ variable "deployment_minimum_healthy_percent" {
   type        = "string"
   default     = "50"
 }
+
+variable "lb_health_check_grace_period_seconds" {
+  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647"
+  type        = "string"
+  default     = "0"
+}


### PR DESCRIPTION
Seconds to ignore failing load balancer health checks on newly
instantiated tasks to prevent premature shutdown, up to 2147483647